### PR TITLE
Fix null pointer exceptions

### DIFF
--- a/src/helpers/array-helpers.js
+++ b/src/helpers/array-helpers.js
@@ -1,6 +1,6 @@
 export function reject(array, callback) {
   const results = [];
-  array.forEach(itemInArray => {
+  (array || []).forEach(itemInArray => {
     if (!callback(itemInArray)) {
       results.push(itemInArray);
     }
@@ -11,7 +11,7 @@ export function reject(array, callback) {
 
 export function filter(array, callback) {
   const results = [];
-  array.forEach(itemInArray => {
+  (array || []).forEach(itemInArray => {
     if (callback(itemInArray)) {
       results.push(itemInArray);
     }


### PR DESCRIPTION
The current version triggers a NPE when one tries to unregister an event type (using `.off(...)`) that does not have any associated handlers.